### PR TITLE
Remove add command exception when duplicate dish added

### DIFF
--- a/src/main/java/calofit/logic/commands/AddCommand.java
+++ b/src/main/java/calofit/logic/commands/AddCommand.java
@@ -33,11 +33,13 @@ public class AddCommand extends Command {
             + PREFIX_CALORIES + "low calories "
             + PREFIX_TAG + "salty";
 
-    public static final String MESSAGE_SUCCESS = "New dish added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New meal added to meal log: %1$s";
     public static final String MESSAGE_DUPLICATE_MEAL = "This dish already exists in the dish database";
     public static final String MESSAGE_MEAL_NOT_IN_DATABASE = "This dish is not in our database. "
             + "Please update the calories using the c/ "
             + "calories set to 700 by default";
+
+    public static final int DEFAULT_MEAL_CALORIE = 700;
 
     private final Dish toAdd;
 
@@ -60,15 +62,17 @@ public class AddCommand extends Command {
             Meal toAddMeal = new Meal(wantToAdd, new Timestamp(LocalDateTime.now()));
             mealLog.addMeal(toAddMeal);
 
-            throw new CommandException(MESSAGE_DUPLICATE_MEAL);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, wantToAdd));
+            //throw new CommandException(MESSAGE_DUPLICATE_MEAL);
         } else {
 
-            if (model.hasDishName(wantToAdd) && !wantToAdd.getCalories().equals(new Calorie(700))) {
+            if (model.hasDishName(wantToAdd) && !wantToAdd.getCalories().equals(new Calorie(DEFAULT_MEAL_CALORIE))) {
                 model.addDish(wantToAdd);
                 Meal toAddMeal = new Meal(wantToAdd, new Timestamp(LocalDateTime.now()));
                 mealLog.addMeal(toAddMeal);
 
-            } else if (model.hasDishName(wantToAdd) && wantToAdd.getCalories().equals(new Calorie(700))) {
+            } else if (model.hasDishName(wantToAdd)
+                    && wantToAdd.getCalories().equals(new Calorie(DEFAULT_MEAL_CALORIE))) {
                 wantToAdd = model.getDishByName(toAdd);
                 if (!wantToAdd.getCalories().equals(toAdd.getCalories())) {
                     wantToAdd = toAdd;

--- a/src/test/java/calofit/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/calofit/logic/commands/AddCommandIntegrationTest.java
@@ -36,10 +36,4 @@ public class AddCommandIntegrationTest {
                 String.format(AddCommand.MESSAGE_SUCCESS, validDish), expectedModel);
     }
 
-    @Test
-    public void execute_duplicateDish_throwsCommandException() {
-        Dish dishInList = model.getDishDatabase().getDishList().get(0);
-        assertCommandFailure(new AddCommand(dishInList), model, AddCommand.MESSAGE_DUPLICATE_MEAL);
-    }
-
 }

--- a/src/test/java/calofit/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/calofit/logic/commands/AddCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package calofit.logic.commands;
 
-import static calofit.logic.commands.CommandTestUtil.assertCommandFailure;
 import static calofit.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/calofit/logic/commands/AddCommandTest.java
+++ b/src/test/java/calofit/logic/commands/AddCommandTest.java
@@ -3,7 +3,6 @@ package calofit.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -12,7 +11,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import calofit.logic.commands.exceptions.CommandException;
 import calofit.model.Model;
 import calofit.model.dish.Dish;
 import calofit.model.dish.DishDatabase;

--- a/src/test/java/calofit/logic/commands/AddCommandTest.java
+++ b/src/test/java/calofit/logic/commands/AddCommandTest.java
@@ -40,19 +40,6 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_duplicateDish_throwsCommandException() {
-        Dish validDish = new DishBuilder().build();
-        MealLog mealLog = new MealLog();
-        Model mock = Mockito.mock(Model.class);
-        Mockito.when(mock.hasDish(validDish)).thenReturn(true);
-        Mockito.when(mock.getMealLog()).thenReturn(mealLog);
-
-        AddCommand addCommand = new AddCommand(validDish);
-
-        assertThrows(CommandException.class, () -> addCommand.execute(mock), AddCommand.MESSAGE_DUPLICATE_MEAL);
-    }
-
-    @Test
     public void equals() {
         Dish alice = new DishBuilder().withName("Alice").build();
         Dish bob = new DishBuilder().withName("Bob").build();


### PR DESCRIPTION
This is because add command no longer adds to the dish database but
instead adds to the meal log as the meal that has been consumed